### PR TITLE
support multiple patterns for a single filter

### DIFF
--- a/ollie/src/main/java/com/walmartlabs/ollie/WebServer.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/WebServer.java
@@ -123,7 +123,10 @@ public class WebServer  {
     }
 
     for (FilterDefinition filterDefinition : webServerDefinition.getFilterDefintions()) {
-      applicationContext.addFilter(new FilterHolder(filterDefinition.getFilterClass()), filterDefinition.getPattern(), null);
+      String[] patterns = filterDefinition.getPatterns();
+      for (String pattern : patterns) {
+        applicationContext.addFilter(new FilterHolder(filterDefinition.getFilterClass()), pattern, null);
+      }
     }
     for (ServletDefinition servletDefinition : webServerDefinition.getServletDefinitions()) {
       if (servletDefinition.getWar() != null) {

--- a/ollie/src/main/java/com/walmartlabs/ollie/WebServerBuilder.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/WebServerBuilder.java
@@ -1,19 +1,16 @@
 package com.walmartlabs.ollie;
 
-import java.io.File;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.walmartlabs.ollie.model.WebServerDefinitionBuilder;
+import org.eclipse.jetty.security.SecurityHandler;
 
 import javax.servlet.Filter;
 import javax.servlet.ServletContextListener;
 import javax.servlet.http.HttpServlet;
-
-import org.eclipse.jetty.security.SecurityHandler;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.walmartlabs.ollie.guice.OllieServerBuilder;
-import com.walmartlabs.ollie.model.WebServerDefinitionBuilder;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
 
 public class WebServerBuilder {
 
@@ -38,7 +35,7 @@ public class WebServerBuilder {
     return this;
   }
 
-  public WebServerBuilder filter(String pattern) {
+  public WebServerBuilder filter(String... pattern) {
     webServerDefinitionBuilder.filter(pattern);
     return this;
   }

--- a/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieServerBuilder.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieServerBuilder.java
@@ -102,7 +102,7 @@ public class OllieServerBuilder extends WebServerBuilder {
     if(filterChains == null) {
       filterChains = Lists.newArrayList();
     }
-    filterChains.add(new FilterDefinition(pattern, filterClass));
+    filterChains.add(new FilterDefinition(new String[] {pattern}, filterClass));
     return this;
   }
 }

--- a/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieServletModule.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieServletModule.java
@@ -93,10 +93,12 @@ public class OllieServletModule extends ServletModule {
       // Authentication Filters
       if (serverConfiguration.filterChains() != null) {
         for (FilterDefinition filterDefinition : serverConfiguration.filterChains()) {
-          String pattern = filterDefinition.getPattern();
-          Class<? extends Filter> filterClass = filterDefinition.getFilterClass();
-          logger.info("Installing authentication filter: {} -> {}.", pattern, filterClass.getName());
-          addFilterChain(pattern, Key.get(filterClass));
+          String[] patterns = filterDefinition.getPatterns();
+          for (String pattern : patterns) {
+            Class<? extends Filter> filterClass = filterDefinition.getFilterClass();
+            logger.info("Installing authentication filter: {} -> {}.", pattern, filterClass.getName());
+            addFilterChain(pattern, Key.get(filterClass));
+          }
         }
       }
     }

--- a/ollie/src/main/java/com/walmartlabs/ollie/model/FilterDefinition.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/model/FilterDefinition.java
@@ -3,23 +3,23 @@ package com.walmartlabs.ollie.model;
 import javax.servlet.Filter;
 
 public class FilterDefinition {
-  String pattern;
+  String[] patterns;
   Class<? extends Filter> filterClass;
 
   public FilterDefinition() {    
   }
 
-  public FilterDefinition(String pattern, Class<? extends Filter> filterClass) {
-    this.pattern = pattern;
+  public FilterDefinition(String[] patterns, Class<? extends Filter> filterClass) {
+    this.patterns = patterns;
     this.filterClass = filterClass;
   }
 
-  public String getPattern() {
-    return pattern;
+  public String[] getPatterns() {
+    return patterns;
   }
 
-  public void setPattern(String pattern) {
-    this.pattern = pattern;
+  public void setPatterns(String... patterns) {
+    this.patterns = patterns;
   }
 
   public Class<? extends Filter> getFilterClass() {
@@ -32,6 +32,6 @@ public class FilterDefinition {
 
   @Override
   public String toString() {
-    return "FilterDefinition [pattern=" + pattern + ", filterClass=" + filterClass + "]";
+    return "FilterDefinition [patterns=" + patterns + ", filterClass=" + filterClass + "]";
   }
 }

--- a/ollie/src/main/java/com/walmartlabs/ollie/model/WebServerDefinitionBuilder.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/model/WebServerDefinitionBuilder.java
@@ -29,9 +29,9 @@ public class WebServerDefinitionBuilder {
     return this;
   }
 
-  public WebServerDefinitionBuilder filter(String pattern) {
+  public WebServerDefinitionBuilder filter(String... patterns) {
     filterDefinition = new FilterDefinition();
-    filterDefinition.setPattern(pattern);
+    filterDefinition.setPatterns(patterns);
     return this;
   }
 


### PR DESCRIPTION
E.g. this
```java
.filter("/service/*", "/api/*", "/logs/*", "/forms/*").through(NoCacheFilter.class)
```
instead of
```java
.filter("/service/*").through(NoCacheFilter.class)
.filter("/api/*").through(NoCacheFilter.class)
.filter("/logs/*").through(NoCacheFilter.class)
.filter("/forms/*").through(NoCacheFilter.class)
```