### PR TITLE
provide a way to override the security module

### DIFF
--- a/ollie/src/main/java/com/walmartlabs/ollie/OllieServerBuilder.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/OllieServerBuilder.java
@@ -32,6 +32,8 @@ import javax.servlet.Filter;
 import javax.servlet.ServletContextListener;
 import javax.servlet.http.HttpServlet;
 
+import com.walmartlabs.ollie.guice.OllieSecurityModule;
+import com.walmartlabs.ollie.guice.OllieSecurityModuleProvider;
 import org.apache.shiro.realm.Realm;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
@@ -96,6 +98,8 @@ public class OllieServerBuilder {
   File secrets;
 
   boolean jmxEnabled = false;
+
+  OllieSecurityModuleProvider securityModuleProvider;
 
   public OllieServer build() {           
     this.contextListener  = new OllieServletContextListener(this);
@@ -375,6 +379,15 @@ public class OllieServerBuilder {
 
   public OllieServerBuilder jmxEnabled(boolean jmxEnabled) {
     this.jmxEnabled = jmxEnabled;
+    return this;
+  }
+
+  public OllieSecurityModuleProvider securityModuleProvider() {
+    return this.securityModuleProvider;
+  }
+
+  public OllieServerBuilder securityModuleProvider(OllieSecurityModuleProvider securityModuleProvider) {
+    this.securityModuleProvider = securityModuleProvider;
     return this;
   }
 

--- a/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieSecurityModule.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieSecurityModule.java
@@ -50,10 +50,14 @@ public class OllieSecurityModule extends AbstractModule {
   @Override
   protected void configure() {
     if (serverConfiguration.realms() != null) {
-      install(new SecurityWebModule(servletContext));
+      install(createSecurityWebModule(servletContext));
       install(new SecurityAnnotationsModule());
       ShiroWebModule.bindGuiceFilter(binder()); // filter(/*).through(GuiceShiroFilter.class)
     }
+  }
+
+  protected SecurityWebModule createSecurityWebModule(ServletContext servletContext) {
+    return new SecurityWebModule(servletContext);
   }
 
   public class SecurityWebModule extends ShiroWebModule {

--- a/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieSecurityModuleProvider.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieSecurityModuleProvider.java
@@ -1,0 +1,30 @@
+package com.walmartlabs.ollie.guice;
+
+/*-
+ * *****
+ * Ollie
+ * -----
+ * Copyright (C) 2018 - 2019 Takari
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.ollie.OllieServerBuilder;
+
+import javax.servlet.ServletContext;
+
+public interface OllieSecurityModuleProvider {
+
+    OllieSecurityModule get(OllieServerBuilder config, ServletContext servletContext);
+}

--- a/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieServletModule.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/guice/OllieServletModule.java
@@ -46,6 +46,11 @@ public class OllieServletModule extends ServletModule {
     }
     serve(apiPattern, jaxRsModule.morePatterns()).with(SiestaServlet.class, jaxRsModule.parameters());
     install(new OllieConfigurationModule(serverConfiguration));
-    install(new OllieSecurityModule(serverConfiguration, getServletContext()));
+
+    OllieSecurityModuleProvider securityModuleProvider = serverConfiguration.securityModuleProvider();
+    if (securityModuleProvider == null) {
+      securityModuleProvider = OllieSecurityModule::new;
+    }
+    install(securityModuleProvider.get(serverConfiguration, getServletContext()));
   }
 }


### PR DESCRIPTION
This is kinda hacky, but we need a way to override the default security module (to, for example, customize `DefaultSecurityManager`, provide our own `RememberMeManager`, etc).