### PR TITLE
configurable requestHeaderSize

### DIFF
--- a/ollie/src/main/java/com/walmartlabs/ollie/OllieServer.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/OllieServer.java
@@ -119,6 +119,7 @@ public class OllieServer {
     HttpConfiguration baseHttpConfiguration = new HttpConfiguration();
     baseHttpConfiguration.setSendServerVersion(false);
     baseHttpConfiguration.setSendXPoweredBy(false);
+    baseHttpConfiguration.setRequestHeaderSize(builder.requestHeaderSize());
 
     ServerConnector httpsConnector;
     if (builder.sslEnabled) {

--- a/ollie/src/main/java/com/walmartlabs/ollie/OllieServerBuilder.java
+++ b/ollie/src/main/java/com/walmartlabs/ollie/OllieServerBuilder.java
@@ -72,6 +72,8 @@ public class OllieServerBuilder {
     int minThreads = 2;
     int maxThreads = 200;
     int threadIdleTimeout = 0;
+    //
+    int requestHeaderSize = 8 * 1024;
 
     boolean sessionsEnabled = false;
     int sessionMaxInactiveInterval = -1;
@@ -273,6 +275,15 @@ public class OllieServerBuilder {
 
     public OllieServerBuilder threadIdleTimeout(int threadIdleTimeout) {
         this.threadIdleTimeout = threadIdleTimeout;
+        return this;
+    }
+
+    public int requestHeaderSize() {
+        return requestHeaderSize;
+    }
+
+    public OllieServerBuilder requestHeaderSize(int requestHeaderSize) {
+        this.requestHeaderSize = requestHeaderSize;
         return this;
     }
 


### PR DESCRIPTION
The Jetty's default (8192) can be too low in some cases - especially in environments with lots of common domain cookies.